### PR TITLE
Add retry logic for AWS throttling errors

### DIFF
--- a/cs/aws_account/regional_account.py
+++ b/cs/aws_account/regional_account.py
@@ -4,7 +4,6 @@ import logging
 import operator
 import types
 
-from botocore.config import Config
 from cachetools import cached
 from zope import interface
 from zope.component.factory import Factory
@@ -12,7 +11,8 @@ from zope.schema.fieldproperty import FieldProperty
 
 from cs.ratelimit import ratelimitedmethod, ratelimitproperties_factory
 
-from .account import account_factory
+from .retry import aws_throttling_retry
+from .account import account_factory, Account as AwsAccount
 from .caching_key import aggregated_string_hash
 from .exceptions import AWSClientException
 from .interfaces import IRegionalAccount
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 @interface.implementer(IRegionalAccount)
 class RegionalAccount:
-    """A boto3 session client caller with rate limiting capabilities.
+    """A   3 session client caller with rate limiting capabilities.
 
     Args:
         ratelimit: cs.ratelimit.RateLimitProperties instance that is referenced
@@ -53,24 +53,26 @@ class RegionalAccount:
         kwargs['service_name'] = service
         kwargs['region_name'] = self.region()
         kwargs.update(self.account().session().client_kwargs(service=service))
-        kwargs['config'] = Config(retries={"max_attempts": 10})
+        kwargs['config'] = AwsAccount.aws_client_config
         return self.account().session().boto3().client(**kwargs)
 
     @ratelimitedmethod(operator.attrgetter('ratelimit'))
+    @aws_throttling_retry()
     def _limited(self, callback, **kwargs):
-        logger.debug("calling AWS method %s for account %s (%s) region %s with user arn %s",
-                     callback,
-                     self._account.account_id(),
-                     self._account.alias(),
-                     self._region_name,
-                     self._account.session().arn())
         try:
+            logger.debug("calling AWS method %s for account %s (%s) region %s with user arn %s",
+                         callback,
+                         self._account.account_id(),
+                         self._account.alias(),
+                         self._region_name,
+                         self._account.session().arn())
             return callback(**kwargs)
         except Exception as exc:
             raise AWSClientException(
                 exc, AccountAlias=self._account.alias(), Region=self._region_name,
                 AccountId=self._account.account_id()) from exc
 
+    @aws_throttling_retry()
     def call_client(self, service, method, client_kwargs=None, **kwargs):
         """Return call to boto3 service client method limited by properties in ratelimit.
 

--- a/cs/aws_account/retry.py
+++ b/cs/aws_account/retry.py
@@ -1,0 +1,46 @@
+"""Retry module for AWS throttling error."""
+import time
+import logging
+
+# pylint: disable=global-variable-not-assigned, invalid-name
+
+
+logger = logging.getLogger(__name__)
+
+
+def aws_throttling_retry(max_retries=5, base=0.5, growth_factor=0.5):
+    """Retry AWS throttling errors with exponential backoff time.
+
+    Calculate time to sleep based on below function.
+    The format is::
+        base + (retries * growth_factor)
+
+    Kwargs:
+    max_retries: Max number of retries when hitting AWS throttling error
+    base: base time for exponential backoff calculation
+    growth_factor: growth factor used to calculate sleeping time for every retry
+    """
+    def decorator_retry(func):
+        def wrapper(*args, **kwargs):  # pylint: disable=inconsistent-return-statements
+            if max_retries < 1:
+                raise ValueError("max_retries can't be less than 1")
+
+            retries = 0
+            while retries < max_retries:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as error:  # pylint: disable=broad-exception-caught
+                    if '(Throttling)' in str(error):
+                        retries += 1
+                        if retries >= max_retries:
+                            logger.warning("Received AWS throttling error. Exhausted all attempts.")
+                            raise error
+                        backoff_seconds = base + (retries * growth_factor)
+                        logger.warning("Received AWS throttling error. Retrying in %s seconds...",
+                                       backoff_seconds)
+                        time.sleep(backoff_seconds)
+                    else:
+                        raise error
+        return wrapper
+
+    return decorator_retry

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,9 +8,9 @@ astroid==2.15.6
     # via pylint
 bandit==1.7.5
     # via cs.aws-account (setup.py)
-boto3==1.28.15
+boto3==1.28.46
     # via cs.aws-account (setup.py)
-botocore==1.31.15
+botocore==1.31.46
     # via
     #   boto3
     #   cs.aws-account (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile
 #
-boto3==1.28.15
+boto3==1.28.46
     # via cs.aws-account (setup.py)
-botocore==1.31.15
+botocore==1.31.46
     # via
     #   boto3
     #   cs.aws-account (setup.py)


### PR DESCRIPTION
Add retry logic for AWS throttling errors, and remove TTL for static caches like account_alias, account_id and arn