### PR TITLE
Update throttling retry logic

### DIFF
--- a/cs/aws_account/retry.py
+++ b/cs/aws_account/retry.py
@@ -30,7 +30,8 @@ def aws_throttling_retry(max_retries=5, base=0.5, growth_factor=0.5):
                 try:
                     return func(*args, **kwargs)
                 except Exception as error:  # pylint: disable=broad-exception-caught
-                    if '(Throttling)' in str(error):
+                    err_str = str(error).lower()
+                    if 'throttling' in err_str or 'rate exceeded' in err_str:
                         retries += 1
                         if retries >= max_retries:
                             logger.warning("Received AWS throttling error. Exhausted all attempts.")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.3.2'
+version = '1.3.3'
 
 tests_require = [
     'zope.testrunner',


### PR DESCRIPTION
Update throttling retry logic to handle different throttling errors like
`botocore.errorfactory.ThrottlingException: An error occurred (ThrottlingException) when calling the DescribeTrustedAdvisorCheckResult operation (reached max retries: 10): Rate exceeded`