### PR TITLE
Perform throttling retry LimitExceeded; allow caller to provide boto client config

### DIFF
--- a/cs/aws_account/regional_account.py
+++ b/cs/aws_account/regional_account.py
@@ -53,7 +53,8 @@ class RegionalAccount:
         kwargs['service_name'] = service
         kwargs['region_name'] = self.region()
         kwargs.update(self.account().session().client_kwargs(service=service))
-        kwargs['config'] = AwsAccount.aws_client_config
+        if 'config' not in kwargs:
+            kwargs['config'] = AwsAccount.aws_client_config
         return self.account().session().boto3().client(**kwargs)
 
     @ratelimitedmethod(operator.attrgetter('ratelimit'))

--- a/cs/aws_account/retry.py
+++ b/cs/aws_account/retry.py
@@ -31,7 +31,7 @@ def aws_throttling_retry(max_retries=5, base=0.5, growth_factor=0.5):
                     return func(*args, **kwargs)
                 except Exception as error:  # pylint: disable=broad-exception-caught
                     err_str = str(error).lower()
-                    if 'throttling' in err_str or 'rate exceeded' in err_str:
+                    if 'throttling' in err_str or 'rate exceeded' in err_str or 'limitexceeded' in err_str:
                         retries += 1
                         if retries >= max_retries:
                             logger.warning("Received AWS throttling error. Exhausted all attempts.")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.3.3'
+version = '1.3.4'
 
 tests_require = [
     'zope.testrunner',


### PR DESCRIPTION
- Add `LimitExceededException` to the types of exceptions that will be retried by the `@aws_throttling_retry` decorator
- Add ability for caller to provide their own boto client Config
- Bump version from `1.3.3` to `1.3.4`

```
config = Config(retries = {'max_attempts': 1, 'mode': 'standard'})
regional_account.call_client('sts', 'get_caller_identity', client_kwargs={"config": config})
```